### PR TITLE
fix QubesOS/qubes-issues#5658, keep python2 in qubesdb.c

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -1,8 +1,6 @@
-# Maintainer: Olivier Medoc <o_medoc@yahoo.fr>
 pkgname=qubes-db-vm
 pkgver=`cat version`
-pkgrel=4
-
+pkgrel=5
 epoch=
 pkgdesc="QubesDB libs and daemon service."
 arch=("x86_64")
@@ -10,7 +8,7 @@ url="http://qubes-os.org/"
 license=('GPL')
 groups=()
 depends=(qubes-libvchan-xen)
-makedepends=(qubes-libvchan-xen python python2)
+makedepends=(qubes-libvchan-xen python)
 checkdepends=()
 optdepends=()
 provides=()
@@ -20,12 +18,9 @@ backup=()
 options=()
 install=PKGBUILD.install
 changelog=
-
 source=()
-
 noextract=()
 md5sums=() #generate with 'makepkg -g'
-
 
 build() {
 
@@ -35,33 +30,19 @@ build() {
   ln -s $srcdir/../include $srcdir/include
   ln -s $srcdir/../python $srcdir/python
 
-  # Build all with python2 bindings
-  PYTHON=python2 make all
-
-  # Build python3 bindings
-  make -C python
+  # Build all with python bindings
+  make all
 
 }
 
 package() {
 
-  # Install all with python2 bindings
-  PYTHON=python2 make install DESTDIR=$pkgdir LIBDIR=/usr/lib BINDIR=/usr/bin SBINDIR=/usr/bin
-
-  # Install python3 bindings
-  make -C python install DESTDIR=$pkgdir LIBDIR=/usr/lib BINDIR=/usr/bin SBINDIR=/usr/bin
+  # Install all with python bindings
+  make install DESTDIR=$pkgdir LIBDIR=/usr/lib BINDIR=/usr/bin SBINDIR=/usr/bin
 
   mkdir -p $pkgdir/usr/lib/systemd/system/
   install -p -m 644 daemon/qubes-db.service $pkgdir/usr/lib/systemd/system/qubes-db.service
 
-#systemctl enable qubes-db.service > /dev/null
-#
-#%preun
-#if [ $1 -eq 0 ]; then
-#    systemctl disable qubes-db.service > /dev/null
-#fi
-
 }
 
 # vim:set ts=2 sw=2 et:
-

--- a/python/qubesdb.c
+++ b/python/qubesdb.c
@@ -19,6 +19,7 @@
  *
  */
 
+#define PY_SSIZE_T_CLEAN 
 #include <Python.h>
 
 #include <stdbool.h>
@@ -128,7 +129,7 @@ static PyObject *qdbpy_write(QdbHandle *self, PyObject *args)
     qdb_handle_t qdb = qdbhandle(self);
     char *path;
     char *data;
-    int data_len;
+    Py_ssize_t data_len;
     bool result;
 
     if (!qdb)
@@ -400,7 +401,7 @@ static int parse_handle_path(QdbHandle *self, PyObject *args,
                                   qdb_handle_t *qdb,
                                   char **path)
 {
-    unsigned int path_len;
+    size_t path_len;
     *qdb = qdbhandle(self);
 
     if (!qdb)


### PR DESCRIPTION
Should fix the warning issue from https://github.com/QubesOS/qubes-issues/issues/5658 

Tested this patch on archlinux and fedora-32. (In this case, 'tested' = 
1. Install and remove a random package => See 'PY_SSIZE_T_CLEAN' warning
2. built and installed this package
3 Install and remove a random package => Didn't see any warning.
).

As discussed in the issue, another [not directly related to this warning issue] pull request should be done specifically for the 'master' branch to completely drop python2. However I won't do it personally soon since I have yet to install R4.1 