### PR TITLE
archlinux: pin PKGBUILD to python3.X major version as new python vers…

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -7,7 +7,10 @@ arch=("x86_64")
 url="http://qubes-os.org/"
 license=('GPL')
 groups=()
-depends=(qubes-libvchan-xen)
+depends=(qubes-libvchan-xen
+  # Block updating if there is a major python update as the python API will be in the wrong PYTHONPATH
+  'python<3.10'
+  )
 makedepends=(qubes-libvchan-xen python)
 checkdepends=()
 optdepends=()


### PR DESCRIPTION
…ion will break the API

Should also be applied to branch 4.1 if possible to cherry-pick.