### PR TITLE
client: Treat getopt(3) return value as int instead of char

### DIFF
--- a/client/qubesdb-cmd.c
+++ b/client/qubesdb-cmd.c
@@ -243,7 +243,7 @@ int main(int argc, char **argv) {
     char *dest_domain = NULL;
     int do_cmd = 0;
     int ret;
-    char opt;
+    int opt;
     qdb_handle_t h;
 
     if ((cmd_argv0=strchr(argv[0], '-'))) {


### PR DESCRIPTION
Per getopt(3)'s man page, the correct return type is int, not char.

Using char is especially problematic on systems where char is
unsigned by default, since that breaks the comparison against -1.
This is the case on ppc64le/elfv2.