### PR TITLE
Use $(file <) instead of $(shell cat)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 RPMS_DIR = rpm/
-VERSION = $(shell cat version)
+VERSION = $(file <version)
 
 help:
 	@echo "make all                   -- compile all binaries"


### PR DESCRIPTION
The former is faster and handles errors (such as permission denied
reading the file) correctly.