### PR TITLE
Implement SELinux policy for QubesDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 rpm/
 deb/
 pkgs/
+/selinux/*.pp
+/selinux/tmp/

--- a/daemon/db-daemon.c
+++ b/daemon/db-daemon.c
@@ -519,6 +519,10 @@ static int init_server_socket(struct db_daemon_data *d) {
     struct stat stat_buf;
     mode_t old_umask;
 
+    if (mkdir("/var/run/qubes", 0775) && errno != EEXIST) {
+        perror("mkdir /var/run/qubes");
+        return 0;
+    }
     if (d->remote_name) {
         snprintf(socket_address, MAX_FILE_PATH,
                 QDB_DAEMON_PATH_PATTERN, d->remote_name);

--- a/daemon/qubes-db.service
+++ b/daemon/qubes-db.service
@@ -4,7 +4,7 @@ After=systemd-modules-load.service fedora-loadmodules.service
 DefaultDependencies=no
 
 [Service]
-ExecStartPre=/bin/mkdir -p /var/run/qubes
+ExecStartPre=/bin/mkdir -pZ /var/run/qubes
 # Remote Dom ID as an argument
 ExecStart=/usr/sbin/qubesdb-daemon 0
 Type=notify

--- a/daemon/qubes-db.service
+++ b/daemon/qubes-db.service
@@ -4,11 +4,12 @@ After=systemd-modules-load.service fedora-loadmodules.service
 DefaultDependencies=no
 
 [Service]
-ExecStartPre=/bin/mkdir -pZ /var/run/qubes
+ExecStartPre=/bin/mkdir -pZ -m 0775 /run/qubes
+ExecStartPre=/bin/chcon -t qubes_var_run_t /run/qubes
 # Remote Dom ID as an argument
 ExecStart=/usr/sbin/qubesdb-daemon 0
 Type=notify
-StandardOutput=syslog
+Group=qubes
 
 [Install]
 WantedBy=sysinit.target

--- a/daemon/qubes-db.service
+++ b/daemon/qubes-db.service
@@ -5,7 +5,6 @@ DefaultDependencies=no
 
 [Service]
 ExecStartPre=/bin/mkdir -pZ -m 0775 /run/qubes
-ExecStartPre=/bin/chcon -t qubes_var_run_t /run/qubes
 # Remote Dom ID as an argument
 ExecStart=/usr/sbin/qubesdb-daemon 0
 Type=notify
@@ -13,4 +12,3 @@ Group=qubes
 
 [Install]
 WantedBy=sysinit.target
-

--- a/daemon/qubes-db.service
+++ b/daemon/qubes-db.service
@@ -4,7 +4,6 @@ After=systemd-modules-load.service fedora-loadmodules.service
 DefaultDependencies=no
 
 [Service]
-ExecStartPre=/bin/mkdir -pZ -m 0775 /run/qubes
 # Remote Dom ID as an argument
 ExecStart=/usr/sbin/qubesdb-daemon 0
 Type=notify

--- a/rpm_spec/qubes-db-vm.spec.in
+++ b/rpm_spec/qubes-db-vm.spec.in
@@ -25,6 +25,8 @@
 # Package contains /usr/lib, but not binary files, which confuses find-debuginfo.sh script.
 %global debug_package %{nil}
 
+%global qubes_db_vm_selinux %{_datadir}/selinux/packages/qubes-core-qubesdb.pp
+
 Name:		qubes-db-vm
 Version:	@VERSION@
 Release:	1%{?dist}
@@ -41,6 +43,36 @@ BuildRequires: systemd
 
 Source0: qubes-db-%{version}.tar.gz
 
+Requires: (%{name}-selinux if selinux-policy)
+%package selinux
+
+BuildRequires: selinux-policy
+BuildRequires: selinux-policy-devel
+%{?selinux_requires}
+
+Summary: SELinux policies for qubesdb
+License: GPLv2+
+
+%description selinux
+The SELinux policies for qubesdb.  You need this package if you want to have
+SELinux enforcing in a qube.
+
+%files selinux
+%{_datadir}/selinux/devel/include/contrib/ipp-qubes-core-qubesdb.if
+%{qubes_db_vm_selinux}
+
+%post selinux
+%selinux_modules_install %{qubes_db_vm_selinux}
+
+%postun selinux
+if [ "$1" -eq 0 ]; then
+    %selinux_modules_uninstall %{qubes_db_vm_selinux}
+fi || :
+
+%posttrans selinux
+%selinux_relabel_post
+exit 0
+
 %description
 QubesDB daemon service.
 
@@ -48,10 +80,14 @@ QubesDB daemon service.
 %setup -q -n qubes-db-%{version}
 
 %build
+make -f /usr/share/selinux/devel/Makefile -C selinux
 
 %install
 install -d %{buildroot}%{_unitdir}
 install -p -m 644 daemon/qubes-db.service %{buildroot}%{_unitdir}/
+
+install -m 0644 -D selinux/qubes-core-qubesdb.if %{buildroot}%{_datadir}/selinux/devel/include/contrib/ipp-qubes-core-qubesdb.if
+install -m 0644 -D -t %{buildroot}%{_datadir}/selinux/packages selinux/qubes-core-qubesdb.pp
 
 %post
 %systemd_post qubes-db.service

--- a/rpm_spec/qubes-db-vm.spec.in
+++ b/rpm_spec/qubes-db-vm.spec.in
@@ -49,6 +49,7 @@ Requires: (%{name}-selinux if selinux-policy)
 BuildRequires: selinux-policy
 BuildRequires: selinux-policy-devel
 %{?selinux_requires}
+Requires: qubes-core-agent-selinux
 
 Summary: SELinux policies for qubesdb
 License: GPLv2+

--- a/selinux/qubes-core-qubesdb.fc
+++ b/selinux/qubes-core-qubesdb.fc
@@ -1,0 +1,3 @@
+/usr/sbin/qubesdb-daemon     -- gen_context(system_u:object_r:qubes_qubesdb_daemon_exec_t,s0)
+/run/qubes/qubesdb\.sock     -s gen_context(system_u:object_r:qubes_qubesdb_socket_t,s0)
+/var/run/qubes/qubesdb\.sock -s gen_context(system_u:object_r:qubes_qubesdb_socket_t,s0)

--- a/selinux/qubes-core-qubesdb.if
+++ b/selinux/qubes-core-qubesdb.if
@@ -1,0 +1,17 @@
+## <summary>
+##	Read and write qubesdb
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed access
+## </summary
+## </param>
+interface(`ipp_qubesdb_talk',`
+	optional_policy(`
+		gen_require(`
+			type qubes_var_run_t, $1;
+		')
+		stream_connect_pattern($1, qubes_var_run_t, qubes_qubesdb_socket_t, qubes_qubesdb_daemon_t)
+		rw_sock_files_pattern($1, qubes_var_run_t, qubes_qubesdb_socket_t)
+	')
+')

--- a/selinux/qubes-core-qubesdb.te
+++ b/selinux/qubes-core-qubesdb.te
@@ -18,9 +18,9 @@ optional {
 	}
 	files_pid_file(qubes_var_run_t)
 	type_transition qubes_qubesdb_daemon_t var_run_t:dir qubes_var_run_t "qubes";
-	type_transition qubes_qubesdb_daemon_t { qubes_var_run_t var_run_t }:sock_file qubes_qubesdb_socket_t "qubesdb.sock";
-	allow qubes_qubesdb_daemon_t { qubes_var_run_t var_run_t }:dir { add_name remove_name search write };
-	allow qubes_qubesdb_daemon_t qubes_var_run_t:dir create;
+	type_transition qubes_qubesdb_daemon_t qubes_var_run_t:sock_file qubes_qubesdb_socket_t "qubesdb.sock";
+	allow qubes_qubesdb_daemon_t var_run_t:dir { add_name search };
+	allow qubes_qubesdb_daemon_t qubes_var_run_t:dir { create add_name remove_name search write };
 }
 
 ipp_qubesdb_talk(xdm_t)

--- a/selinux/qubes-core-qubesdb.te
+++ b/selinux/qubes-core-qubesdb.te
@@ -14,11 +14,13 @@ dev_rw_xen(qubes_qubesdb_daemon_t)
 
 optional {
 	require {
-		type qubes_var_run_t;
+		type qubes_var_run_t, var_run_t;
 	}
 	files_pid_file(qubes_var_run_t)
-	type_transition qubes_qubesdb_daemon_t qubes_var_run_t:sock_file qubes_qubesdb_socket_t "qubesdb.sock";
-	allow qubes_qubesdb_daemon_t qubes_var_run_t:dir { add_name remove_name search write };
+	type_transition qubes_qubesdb_daemon_t var_run_t:dir qubes_var_run_t "qubes";
+	type_transition qubes_qubesdb_daemon_t { qubes_var_run_t var_run_t }:sock_file qubes_qubesdb_socket_t "qubesdb.sock";
+	allow qubes_qubesdb_daemon_t { qubes_var_run_t var_run_t }:dir { add_name remove_name search write };
+	allow qubes_qubesdb_daemon_t qubes_var_run_t:dir create;
 }
 
 ipp_qubesdb_talk(xdm_t)

--- a/selinux/qubes-core-qubesdb.te
+++ b/selinux/qubes-core-qubesdb.te
@@ -19,7 +19,7 @@ optional {
 	files_pid_file(qubes_var_run_t)
 	type_transition qubes_qubesdb_daemon_t var_run_t:dir qubes_var_run_t "qubes";
 	type_transition qubes_qubesdb_daemon_t qubes_var_run_t:sock_file qubes_qubesdb_socket_t "qubesdb.sock";
-	allow qubes_qubesdb_daemon_t var_run_t:dir { add_name search };
+	allow qubes_qubesdb_daemon_t var_run_t:dir { add_name search write };
 	allow qubes_qubesdb_daemon_t qubes_var_run_t:dir { create add_name remove_name search write };
 }
 

--- a/selinux/qubes-core-qubesdb.te
+++ b/selinux/qubes-core-qubesdb.te
@@ -1,0 +1,31 @@
+policy_module(qubes-core-qubesdb, 0.0.1)
+
+type qubes_qubesdb_daemon_t;
+type qubes_qubesdb_daemon_exec_t;
+type qubes_qubesdb_socket_t;
+attribute qubes_qubesdb_access;
+files_pid_file(qubes_qubesdb_socket_t)
+init_daemon_domain(qubes_qubesdb_daemon_t, qubes_qubesdb_daemon_exec_t)
+allow qubes_qubesdb_daemon_t self:process fork;
+allow qubes_qubesdb_daemon_t self:unix_dgram_socket { create getopt setopt write };
+kernel_dgram_send(qubes_qubesdb_daemon_t)
+allow qubes_qubesdb_daemon_t qubes_qubesdb_socket_t:sock_file { create getattr unlink };
+dev_rw_xen(qubes_qubesdb_daemon_t)
+
+optional {
+	require {
+		type qubes_var_run_t;
+	}
+	files_pid_file(qubes_var_run_t)
+	type_transition qubes_qubesdb_daemon_t qubes_var_run_t:sock_file qubes_qubesdb_socket_t "qubesdb.sock";
+	allow qubes_qubesdb_daemon_t qubes_var_run_t:dir { add_name remove_name search write };
+}
+
+ipp_qubesdb_talk(xdm_t)
+ipp_qubesdb_talk(xend_t)
+ipp_qubesdb_talk(NetworkManager_t)
+ipp_qubesdb_talk(local_login_t)
+ipp_qubesdb_talk(pulseaudio_t)
+ipp_qubesdb_talk(staff_t)
+ipp_qubesdb_talk(sysadm_t)
+ipp_qubesdb_talk(udev_t)


### PR DESCRIPTION
This allows using QubesDB with SELinux enforcing.  Part of QubesOS/qubes-issues#4239.