### PR TITLE
archlinux: bump python dependency to v3.11

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=qubes-db-vm
 pkgver=`cat version`
-pkgrel=5
+pkgrel=6
 epoch=
 pkgdesc="QubesDB libs and daemon service."
 arch=("x86_64")
@@ -9,7 +9,7 @@ license=('GPL')
 groups=()
 depends=(qubes-libvchan
   # Block updating if there is a major python update as the python API will be in the wrong PYTHONPATH
-  'python<3.10'
+  'python<3.11'
   )
 makedepends=(qubes-libvchan python)
 checkdepends=()


### PR DESCRIPTION
The python dependecy should be updated. This change should be also backported to PKGBUILD for Qubes v4.0.

- https://github.com/QubesOS/qubes-issues/issues/7121