### PR TITLE
Add command to check if a path in qubesdb exists

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -20,6 +20,7 @@ install: all
 	ln -s qubesdb-cmd $(DESTDIR)$(BINDIR)/qubesdb-multiread
 	ln -s qubesdb-cmd $(DESTDIR)$(BINDIR)/qubesdb-list
 	ln -s qubesdb-cmd $(DESTDIR)$(BINDIR)/qubesdb-watch
+	ln -s qubesdb-cmd $(DESTDIR)$(BINDIR)/qubesdb-exists
 	install qubesdb-read-bool $(DESTDIR)$(BINDIR)/
 
 .PHONY: libqubesdb

--- a/debian/qubesdb.install
+++ b/debian/qubesdb.install
@@ -5,4 +5,5 @@ usr/bin/qubesdb-rm
 usr/bin/qubesdb-multiread
 usr/bin/qubesdb-list
 usr/bin/qubesdb-watch
+usr/bin/qubesdb-exists
 usr/sbin/qubesdb-daemon

--- a/rpm_spec/qubes-db.spec.in
+++ b/rpm_spec/qubes-db.spec.in
@@ -90,6 +90,7 @@ make install \
 %{_bindir}/qubesdb-multiread
 %{_bindir}/qubesdb-list
 %{_bindir}/qubesdb-watch
+%{_bindir}/qubesdb-exists
 %{_sbindir}/qubesdb-daemon
 
 %files libs


### PR DESCRIPTION
qubesdb-exists will be used in the firewall code to check if a given network device is going to be part of a bridge or not.