### PR TITLE
Update archlinux python version dependency to <3.12

### DIFF
--- a/archlinux/PKGBUILD.in
+++ b/archlinux/PKGBUILD.in
@@ -14,7 +14,7 @@ depends=(
   python-setuptools
   qubes-libvchan
   # Block updating if there is a major python update as the python API will be in the wrong PYTHONPATH
-  'python<3.11'
+  'python<3.12'
   )
 install=archlinux/PKGBUILD.install
 _pkgnvr="${pkgname}-${pkgver}-${pkgrel}"


### PR DESCRIPTION
Update the python dependency for ArchLinux.

Related to https://github.com/QubesOS/qubes-issues/issues/8170