### PR TITLE
Update archlinux python version dependency to <3.13

### DIFF
--- a/archlinux/PKGBUILD.in
+++ b/archlinux/PKGBUILD.in
@@ -14,7 +14,7 @@ depends=(
   python-setuptools
   qubes-libvchan
   # Block updating if there is a major python update as the python API will be in the wrong PYTHONPATH
-  'python<3.12'
+  'python<3.13'
   )
 install=archlinux/PKGBUILD.install
 _pkgnvr="${pkgname}-${pkgver}-${pkgrel}"


### PR DESCRIPTION
ArchLinux switched to python-3.12, this PR fixes the QubesOS/qubes-issues/issues/9171 issue for qubes-core-qubesdb.