### PR TITLE
python: avoid conflicting _FORTIFY_SOURCE values

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -1,7 +1,10 @@
-
+import os
 from setuptools import setup, Extension
 
 extra_compile_args  = [ "-fno-strict-aliasing", "-Werror" ]
+
+if "-D_FORTIFY_SOURCE=" in os.environ.get("CFLAGS", ""):
+    os.environ["CFLAGS"] = "-Wp,-U_FORTIFY_SOURCE " + os.environ["CFLAGS"]
 
 PATH_INCLUDES      = "../include"
 PATH_LIBS          = "../client"


### PR DESCRIPTION
The compile flags are combined from python's build config (sysconfig
module) and CFLAGS environment. If both define the _FORTIFY_SOURCE but
to different values, the build will fail. This is the case on Arch,
where Python's sysconfig has -D_FORTIFY_SOURCE=2, while Arch's
makepkg.conf has -D_FORTIFY_SOURCE=3. Resolve the config by undefining
_FORTIFY_SOURCE first, and use the value from the CFLAGS environment.
Details:
https://setuptools.pypa.io/en/latest/userguide/ext_modules.html

Fixes https://github.com/QubesOS/qubes-core-agent-linux/pull/496#issuecomment-2084833750