### PR TITLE
Bump Python version dependency in Arch packages

### DIFF
--- a/archlinux/PKGBUILD.in
+++ b/archlinux/PKGBUILD.in
@@ -14,7 +14,7 @@ depends=(
   python-setuptools
   qubes-libvchan
   # Block updating if there is a major python update as the python API will be in the wrong PYTHONPATH
-  'python<3.13'
+  'python<3.14'
   )
 install=archlinux/PKGBUILD.install
 _pkgnvr="${pkgname}-${pkgver}-${pkgrel}"


### PR DESCRIPTION
Arch just bumped to Python 3.13.