### PR TITLE
Ensure that qubesdb SELinux labels are correct

### DIFF
--- a/selinux/qubes-core-qubesdb.fc
+++ b/selinux/qubes-core-qubesdb.fc
@@ -1,3 +1,4 @@
 /usr/sbin/qubesdb-daemon     -- gen_context(system_u:object_r:qubes_qubesdb_daemon_exec_t,s0)
+/usr/bin/qubesdb-daemon      -- gen_context(system_u:object_r:qubes_qubesdb_daemon_exec_t,s0)
 /run/qubes/qubesdb\.sock     -s gen_context(system_u:object_r:qubes_qubesdb_socket_t,s0)
 /var/run/qubes/qubesdb\.sock -s gen_context(system_u:object_r:qubes_qubesdb_socket_t,s0)


### PR DESCRIPTION
/usr/sbin is now considered an alias for /usr/bin, so include rules for /usr/bin to ensure correct labelling.  Do not remove the old rules to avoid regression on Fedora 40.

Suggested-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
Part-of: QubesOS/qubes-issues#9663