### PR TITLE
rpm: adjust SELinux snippets for relabeling

### DIFF
--- a/rpm_spec/qubes-db-vm.spec.in
+++ b/rpm_spec/qubes-db-vm.spec.in
@@ -62,6 +62,9 @@ SELinux enforcing in a qube.
 %{_datadir}/selinux/devel/include/contrib/ipp-qubes-core-qubesdb.if
 %{qubes_db_vm_selinux}
 
+%pre selinux
+%selinux_relabel_pre
+
 %post selinux
 %selinux_modules_install %{qubes_db_vm_selinux}
 


### PR DESCRIPTION
Adjust according to https://fedoraproject.org/wiki/SELinux/IndependentPolicy#Creating_the_Spec_File

Specifically, when %selinux_relabel_post is used, %selinux_relabel_pre
needs to be there too.

QubesOS/qubes-issues#9663