### PR TITLE
Move all binaries from /usr/sbin to /usr/bin

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,3 +7,11 @@ include:
   project: QubesOS/qubes-continuous-integration
 - file: /r4.2/gitlab-vm.yml
   project: QubesOS/qubes-continuous-integration
+- file: /r4.3/gitlab-base.yml
+  project: QubesOS/qubes-continuous-integration
+# - file: /r4.3/gitlab-host-qwt.yml
+#   project: QubesOS/qubes-continuous-integration
+- file: /r4.3/gitlab-host.yml
+  project: QubesOS/qubes-continuous-integration
+- file: /r4.3/gitlab-vm.yml
+  project: QubesOS/qubes-continuous-integration

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -24,13 +24,13 @@ LIBS += -L$(QUBES_LIBS) -lvchan
 endif
 CFLAGS += -DBACKEND_VMM_$(BACKEND_VMM)
 
-SBINDIR ?= /usr/sbin
+BINDIR ?= /usr/bin
 
 all: qubesdb-daemon$(EXEEXT)
 
 install:
-	install -d $(DESTDIR)$(SBINDIR)
-	install qubesdb-daemon$(EXEEXT) $(DESTDIR)$(SBINDIR)/
+	install -d $(DESTDIR)$(BINDIR)
+	install qubesdb-daemon$(EXEEXT) $(DESTDIR)$(BINDIR)/
 
 qubesdb-daemon$(EXEEXT): db-cmds.o db-daemon.o db-core.o buffer.o
 	$(CC) $(LDFLAGS) -o $@ $^ $(APPEND_LDFLAGS) $(LIBS)

--- a/daemon/qubes-db-dom0.service
+++ b/daemon/qubes-db-dom0.service
@@ -4,7 +4,7 @@ After=systemd-tmpfiles-setup.service
 
 [Service]
 # Both agent and daemon for dom0
-ExecStart=/usr/sbin/qubesdb-daemon 0 dom0
+ExecStart=/usr/bin/qubesdb-daemon 0 dom0
 Type=notify
 StandardOutput=syslog
 

--- a/daemon/qubes-db.service
+++ b/daemon/qubes-db.service
@@ -5,7 +5,7 @@ DefaultDependencies=no
 
 [Service]
 # Remote Dom ID as an argument
-ExecStart=/usr/sbin/qubesdb-daemon 0
+ExecStart=/usr/bin/qubesdb-daemon 0
 Type=notify
 Group=qubes
 

--- a/debian/qubesdb.install
+++ b/debian/qubesdb.install
@@ -5,4 +5,4 @@ usr/bin/qubesdb-rm
 usr/bin/qubesdb-multiread
 usr/bin/qubesdb-list
 usr/bin/qubesdb-watch
-usr/sbin/qubesdb-daemon
+usr/bin/qubesdb-daemon

--- a/rpm_spec/qubes-db.spec.in
+++ b/rpm_spec/qubes-db.spec.in
@@ -78,6 +78,10 @@ make install \
          LIBDIR=%{_libdir} \
          BINDIR=%{_bindir} \
          SBINDIR=%{_sbindir}
+%if "%{_sbindir}" != "%{_bindir}"
+mkdir -p %{buildroot}%{_sbindir}
+ln -s ../bin/qubesdb-daemon %{buildroot}%{_sbindir}/qubesdb-daemon
+%endif
 
 %files
 %doc
@@ -89,7 +93,10 @@ make install \
 %{_bindir}/qubesdb-multiread
 %{_bindir}/qubesdb-list
 %{_bindir}/qubesdb-watch
+%{_bindir}/qubesdb-daemon
+%if "%{_sbindir}" != "%{_bindir}"
 %{_sbindir}/qubesdb-daemon
+%endif
 
 %files libs
 %{_libdir}/libqubesdb.so

--- a/selinux/qubes-core-qubesdb.fc
+++ b/selinux/qubes-core-qubesdb.fc
@@ -1,4 +1,3 @@
-/usr/sbin/qubesdb-daemon     -- gen_context(system_u:object_r:qubes_qubesdb_daemon_exec_t,s0)
 /usr/bin/qubesdb-daemon      -- gen_context(system_u:object_r:qubes_qubesdb_daemon_exec_t,s0)
 /run/qubes/qubesdb\.sock     -s gen_context(system_u:object_r:qubes_qubesdb_socket_t,s0)
 /var/run/qubes/qubesdb\.sock -s gen_context(system_u:object_r:qubes_qubesdb_socket_t,s0)


### PR DESCRIPTION
In practice only qubesdb-daemon remained in /usr/sbin.
Since Fedora 42 merged those two, it ends up in /usr/bin anyway, and
since its harmless on other distros, move it everywhere. This simplifies
for example systemd unit handling (which otherwise would sometimes need
/usr/bin and sometimes /usr/sbin path).

QubesOS/qubes-issues#9807