### PR TITLE
Windows: Local build fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,5 @@
 rpm/
 deb/
 pkgs/
-/.artifacts/
 /selinux/*.pp
 /selinux/tmp/

--- a/windows/clean.cmd
+++ b/windows/clean.cmd
@@ -1,4 +1,3 @@
-rd /s /q %~dp0\..\.artifacts
 rd /s /q %~dp0\vs2022\tmp
 rd /s /q %~dp0\vs2022\x64
 del /q /a /f %~dp0\sign.crt

--- a/windows/clean.cmd
+++ b/windows/clean.cmd
@@ -1,5 +1,5 @@
 rd /s /q %~dp0\..\.artifacts
 rd /s /q %~dp0\vs2022\tmp
 rd /s /q %~dp0\vs2022\x64
-del /s /q /f %~dp0\sign.crt
-del /s /q /f %~dp0\qwt_version.h
+del /q /a /f %~dp0\sign.crt
+del /q /a /f %~dp0\qwt_version.h


### PR DESCRIPTION
- windows: Fix local clean script
- windows: Don't use local .artifacts dir (remove redundant symlinking/copying for local build)